### PR TITLE
fix: update windows binary regex

### DIFF
--- a/src/readme-updater.ts
+++ b/src/readme-updater.ts
@@ -3,7 +3,7 @@ import { logger as defaultLogger, type Logger } from 'release-please/build/src/u
 
 export class UpdateVersionsInReadme extends DefaultUpdater {
   getRegex (oldVersion: string): RegExp {
-    return new RegExp(`((?:ipfs-desktop|IPFS-Desktop-Setup|ipfs-desktop/releases/tag|ipfs-desktop/releases/download)[-/]v?)${oldVersion}`, 'gm')
+    return new RegExp(`((?:ipfs-desktop|IPFS-Desktop-Setup|ipfs-desktop-setup|ipfs-desktop/releases/tag|ipfs-desktop/releases/download)[-/]v?)${oldVersion}`, 'gm')
   }
 
   updateContent (content: string, logger: Logger = defaultLogger): string {


### PR DESCRIPTION
Windows link did not update in README on release, I had to update manually:
- https://github.com/ipfs/ipfs-desktop/commit/baced38e4053be2d5e69ac1cd43d62ccad28887d

I think this is because regex is very crude and assumes windows name to be camel case, while it is now lowercase.

@SgtPooki I think semantic release is broken in main branch, mind taking a look before merging this?